### PR TITLE
Use system default, fix install instruction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ all: open
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S), Darwin)
 	OPEN := open
+else ifeq ($(UNAME_S), Linux)
+	OPEN := xdg-open
 else
 	OPEN := acroread
 endif

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ## You need ##
 * the Fontin font (available [here](http://www.exljbris.com/fontin.html))
 * xelatex
+* layaureo.sty (found in the texlive italian package)
 
 ## To build ##
 


### PR DESCRIPTION
- I don't have acroread on my system, better use the xdg defaults
- While trying to build it, with the english version of texlive, I remarque that without `layaureo.sty` it would not work
